### PR TITLE
Support low confidence translations

### DIFF
--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -293,7 +293,7 @@ def exit_deadends(
                         label[key] += deadend_label[key]
                     else:
                          label[key] += (
-                        "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."
+                        "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent (Default Message)"
                     )
 
                 note_node = Node(name="segment_note")

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -276,11 +276,27 @@ def exit_deadends(
                     for key, value in settings_config.items()
                     if key.startswith("segment_note")
                 }
-                label = {key: value.format(segment=segment) for key, value in note_label.items()}
+                label = {
+                    key: value.format(segment=segment)
+                    for key, value in note_label.items()
+                }
+
+                # Dead-end low confidence note from settings_config: deadend_note::English (en)/deadend_note::French (fr)
+                deadend_prefix = "deadend_note"
+                deadend_labels = {
+                    key.replace(deadend_prefix, "label"): value
+                    for key, value in settings_config.items()
+                    if key.startswith(deadend_prefix)
+                }
+
                 for key in label:
-                    label[key] += (
+                    if key in deadend_labels:
+                        label[key] += deadend_labels[key]
+                    else:
+                         label[key] += (
                         "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."
                     )
+
                 note_node = Node(name="segment_note")
                 note = Question(name=note_node.uid, type="note", label=label)
                 note_node.question = note
@@ -288,3 +304,5 @@ def exit_deadends(
                 new_node.add_child(note_node)
 
     return new_root
+
+

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -293,7 +293,7 @@ def exit_deadends(
                         label[key] += deadend_label[key]
                     else:
                          label[key] += (
-                        "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent (Default Message)"
+                        "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."
                     )
 
                 note_node = Node(name="segment_note")

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -281,17 +281,16 @@ def exit_deadends(
                     for key, value in note_label.items()
                 }
 
-                # Dead-end low confidence note from settings_config: deadend_note::English (en)/deadend_note::French (fr)
-                deadend_prefix = "deadend_note"
-                deadend_labels = {
-                    key.replace(deadend_prefix, "label"): value
+                # create note for dead-end
+                deadend_label = {
+                    key.replace("deadend_note", "label"): value
                     for key, value in settings_config.items()
-                    if key.startswith(deadend_prefix)
+                    if key.startswith("deadend_note")
                 }
 
                 for key in label:
-                    if key in deadend_labels:
-                        label[key] += deadend_labels[key]
+                    if key in deadend_label:
+                        label[key] += deadend_label[key]
                     else:
                          label[key] += (
                         "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."


### PR DESCRIPTION
**Summary**

This PR adds support for configuring dead-end notes via the [excel](https://docs.google.com/spreadsheets/d/1OasNkaiwE03YFGkttN3YjgniZtnNGr22ZF76Y-F-UxQ/edit?gid=597352189#gid=597352189) configuration file `settings` sheet.

A new code snippet was introduced to read the segment_note_* label from the configuration and use it when generating dead-end notes. If a note is not configured in the excel file, it falls back to a default hard-coded message.

**Testing**

Testing was performed using the create-xlsform [pipeline](https://app.openhexa.org/workspaces/pathways-indonesia-2022dhs7/pipelines/create-xlsform/) in the Indonesia workspace 

Below is an example of the resulting dead-end note after the changes:

<img width="655" height="531" alt="image" src="https://github.com/user-attachments/assets/e146d75b-4e3a-4cb1-ab05-a4ffad6ff008" />


