### PR TITLE
Include class prob mermaid

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -80,7 +80,7 @@ def create_cart_diagram(root: Node) -> str:
 
     for node in root.preorder():
         probabilities = getattr(node, "class_probabilities", None)
-        
+
         if node.is_leaf and probabilities:
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "stadium"

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -165,8 +165,8 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
         links.append(link)
 
         # for leaf nodes, draw arrows to all segments with prob > 0 ---
-        if getattr(node, "class_probabilities", None) and node.is_leaf:
-            for segment_name, prob in node.cluster_probabilities.items():
+        if node.name == "segment" and node.class_probabilities:
+            for segment_name, prob in node.class_probabilities.items():
                 if not prob or prob <= 0:
                     continue
                 # ensure we have a shape for this segment "probability" node

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -70,23 +70,26 @@ def _link_label(node: Node) -> str:
     msg = f"Unsupported operator: {ope}"
     raise MermaidError(msg)
 
-# we need to update this diagram too
 def create_cart_diagram(root: Node) -> str:
     """Create mermaid diagram for CART."""
     header = "flowchart TD"
 
     shapes_lst = []
+    links = []
+    
     for node in root.preorder():
         if node.is_leaf:
-            label = node.cart.cluster
-            shape_type = "stadium"
+            probabilities = node.class_probabilities
+            prob_shapes, prob_links = create_segment_probability_stack(
+                node, probabilities, "stadium"
+            )
+            shapes_lst.extend(prob_shapes)
+            links.extend(prob_links)
         else:
             label = node.cart.left.var
-            shape_type = "rectangle"
-        shape = draw_shape(node.uid, label, shape_type)
-        shapes_lst.append(shape)
+            shape = draw_shape(node.uid, label, "rectangle")
+            shapes_lst.append(shape)
 
-    links = []
     for node in root.preorder():
         if node.is_root:
             continue

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -174,7 +174,7 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
                     segment_shape_type = shapes["segment"]
                     segment_label = segment_name
                     segment_shape = draw_shape(
-                        segment_name,  # mermaid id for this segment node
+                        segment_name,  
                         segment_label,
                         segment_shape_type,
                     )
@@ -184,8 +184,8 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
                 # link from this leaf node to the segment node, with probability as label
                 prob_label = f"{prob:.2f}"  # or f"{prob*100:.0f}%" if you prefer %
                 prob_link = draw_link(
-                    shape_a=node.question.name,  # from this leaf node
-                    shape_b=segment_name,        # to the segment node
+                    shape_a=node.uid,           # from this leaf node (UID matches shape created above)
+                    shape_b=segment_name,       # to the segment node
                     label=prob_label,
                 )
                 links.append(prob_link)

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -188,7 +188,7 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
         if skip_notes and node.question.type == "note":
             continue
 
-        is_segment_leaf = node.name == "Segment"
+        is_segment_leaf = node.name == "segment"
 
         if is_segment_leaf:
             probabilities = node.class_probabilities

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -19,7 +19,7 @@ ShapeType = Literal[
     "stadium",
     "hexagon",
     "parallelogram",
-    "prallelogram_alt",
+    "parallelogram_alt",
     "circle",
     "trapezoid",
     "trapezoid_alt",
@@ -79,13 +79,19 @@ def create_cart_diagram(root: Node) -> str:
     links = []
 
     for node in root.preorder():
-        if node.is_leaf:
-            probabilities = node.class_probabilities
+        probabilities = getattr(node, "class_probabilities", None)
+        
+        if node.is_leaf and probabilities:
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "stadium"
             )
             shapes_lst.extend(prob_shapes)
             links.extend(prob_links)
+        elif node.is_leaf:
+            # Leaf without probabilities (fallback)
+            label = node.cart.cluster
+            shape = draw_shape(node.uid, label, "stadium")
+            shapes_lst.append(shape)
         else:
             label = node.cart.left.var
             shape = draw_shape(node.uid, label, "rectangle")
@@ -189,16 +195,16 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
             continue
 
         is_segment_leaf = node.name == "segment"
+        probabilities = getattr(node, "class_probabilities", None)
 
-        if is_segment_leaf:
-            probabilities = node.class_probabilities
+        if is_segment_leaf and probabilities:
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "circle"
             )
             shapes_lst.extend(prob_shapes)
             links.extend(prob_links)
         else:
-            shape_type = shapes[node.question.type]
+            shape_type = "circle" if is_segment_leaf else shapes[node.question.type]
             shape_label = get_form_shape_label(node)
             shape = draw_shape(node.uid, shape_label, shape_type)
             shapes_lst.append(shape)

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -243,9 +243,9 @@ def exit_deadends(
                     for choice in choices_config[var]:
                         if choice["target_value"] == cart_value:
                             deadend_choices_xlsform.append(choice["name"])
-                assert len(deadend_choices_xlsform) == len(
-                    deadend_choices
-                ), "Some deadend choices were not found in choices_config"
+                assert len(deadend_choices_xlsform) == len(deadend_choices), (
+                    "Some deadend choices were not found in choices_config"
+                )
                 deadend_choices = deadend_choices_xlsform
 
                 # Get segment name from cluster number
@@ -276,10 +276,7 @@ def exit_deadends(
                     for key, value in settings_config.items()
                     if key.startswith("segment_note")
                 }
-                label = {
-                    key: value.format(segment=segment)
-                    for key, value in note_label.items()
-                }
+                label = {key: value.format(segment=segment) for key, value in note_label.items()}
 
                 # create note for dead-end
                 deadend_label = {
@@ -292,9 +289,9 @@ def exit_deadends(
                     if key in deadend_label:
                         label[key] += deadend_label[key]
                     else:
-                         label[key] += (
-                        "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."
-                    )
+                        label[key] += (
+                            "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."
+                        )
 
                 note_node = Node(name="segment_note")
                 note = Question(name=note_node.uid, type="note", label=label)
@@ -303,5 +300,3 @@ def exit_deadends(
                 new_node.add_child(note_node)
 
     return new_root
-
-

--- a/pathways/typing/tree.py
+++ b/pathways/typing/tree.py
@@ -130,8 +130,6 @@ def generate_uid(prefix: str) -> str:
     name = prefix.lower().replace(".", "_")
     return f"{name}_{suffix}"
 
-# This is where I need to change to update the tree structure for the form 
-# that the mermaid diagram will represent
 class Node:
     """A node in the typing tree."""
 
@@ -227,7 +225,7 @@ class Node:
             yield from child.postorder()
         yield self
 
-# isn't this the same function of parse cart in cart.py?
+
 def parse_rpart(
     nodes: list[dict], ylevels: list[str], xlevels: dict[str, list[str]], csplit: list[list]
 ) -> dict[int, CARTNode]:

--- a/pathways/typing/tree.py
+++ b/pathways/typing/tree.py
@@ -130,7 +130,8 @@ def generate_uid(prefix: str) -> str:
     name = prefix.lower().replace(".", "_")
     return f"{name}_{suffix}"
 
-
+# This is where I need to change to update the tree structure for the form 
+# that the mermaid diagram will represent
 class Node:
     """A node in the typing tree."""
 
@@ -148,6 +149,7 @@ class Node:
         self.question: Question | None = None
         self.uid: str = generate_uid(name)
         self.conditions: list[str] = []
+        self.class_probabilities: dict[str, float] | None = None
 
     def __repr__(self) -> str:
         return f"Node(name={self.name}, uid={self.uid})"
@@ -225,7 +227,7 @@ class Node:
             yield from child.postorder()
         yield self
 
-
+# isn't this the same function of parse cart in cart.py?
 def parse_rpart(
     nodes: list[dict], ylevels: list[str], xlevels: dict[str, list[str]], csplit: list[list]
 ) -> dict[int, CARTNode]:
@@ -311,6 +313,7 @@ def build_tree(cart_nodes: dict[int, CARTNode], strata: Strata) -> Node:
         n.strata = node.strata
         n.cart = node
         n.cart.strata = strata
+        n.class_probabilities = node.class_probabilities
         nodes[i] = n
 
     for i, node in nodes.items():

--- a/pathways/typing/tree.py
+++ b/pathways/typing/tree.py
@@ -313,7 +313,7 @@ def build_tree(cart_nodes: dict[int, CARTNode], strata: Strata) -> Node:
         n.strata = node.strata
         n.cart = node
         n.cart.strata = strata
-        n.class_probabilities = node.class_probabilities
+        n.class_probabilities = node.cluster_probabilities
         nodes[i] = n
 
     for i, node in nodes.items():


### PR DESCRIPTION
**Summary of Changes:**

**`1. tree.py`**

- Added `class_probabilities` instance variable to `Node` class 
- Populated it during tree construction with cluster probability distributions from the CART model output

**`2. mermaid.py`**

- Added `"create_segment_probability_stack"` helper function that generates stacked visualization for segment nodes with classification probabilities. The function orders segments by probability (highest to lowest) and creates a vertical stack of shapes connected by links, with each shape displaying the segment name and its probability percentage.
- In `"create_form_diagram"` :
If a segment node has probabilities: Creates a stacked visualization using the helper function with circle shapes
Otherwise: Continues with the original single-shape rendering behavior
Included fallback logic for segments without probabilities to handle cases where probability data may not yet be available during tree construction or dead-ends
- The same logic applies to `"create_cart_diagram"`

The changes in `options.py` can be ignored, they are just formatting updates, no logic changes

**Note**
- Currently, segment nodes are drawn as 'circle' in form diagram while it is 'stadium' in CART diagram. This may be intentional from a design perspective (or it may not matter as both don't have a specific meaning) but if it's required that both diagrams match, please let me know if I need to change the segment node shapes to match both diagrams
- The current implementation uses a vertical stacking approach to match the screenshot attached in the ticket. There was also another idea which is to use a fan-out approach (all segments branching directly from the parent question) but then the order of highest to lowest probability won't be as visible at first glance. But this could be implemented if needed, though the code for creating links would be more complicated.

**Testing using IDN Data**
-Pasted both txt files on whimsical and this is the output
[CART Diagram](https://whimsical.com/tt-cart-test-KaudBMk1uQgpEiuWPSGnuA)
[Form Diagram ](https://whimsical.com/tt-form-test-2Ejr1UzFKpQmJvqrWSg7Qt)

**Jira Ticket Links**
https://bluesquare.atlassian.net/browse/PATHWAYS-1083
https://bluesquare.atlassian.net/browse/PATHWAYS-1084

