### PR TITLE
Low confidence threshold

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -174,7 +174,7 @@ def create_segment_probability_stack(
     return shapes, links
 
 
-def create_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float) -> str:
+def create_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
     """Create mermaid diagram for typing form."""
     header = "flowchart TD"
     threshold = threshold / 100.0

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -79,7 +79,7 @@ def create_cart_diagram(root: Node) -> str:
     links = []
 
     for node in root.preorder():
-        probabilities = getattr(node, "class_probabilities", None)
+        probabilities = node.class_probabilities
 
         if node.is_leaf and probabilities:
             prob_shapes, prob_links = create_segment_probability_stack(
@@ -195,7 +195,7 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
             continue
 
         is_segment_leaf = node.name == "segment"
-        probabilities = getattr(node, "class_probabilities", None)
+        probabilities = node.class_probabilities
 
         if is_segment_leaf and probabilities:
             prob_shapes, prob_links = create_segment_probability_stack(

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -174,9 +174,10 @@ def create_segment_probability_stack(
     return shapes, links
 
 
-def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
+def create_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float) -> str:
     """Create mermaid diagram for typing form."""
     header = "flowchart TD"
+    threshold = threshold / 100.0
     shapes = {
         "segment": "stadium",
         "select_one": "rectangle",
@@ -198,11 +199,17 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False) -> str:
         probabilities = node.class_probabilities
 
         if is_segment_leaf and probabilities:
-            prob_shapes, prob_links = create_segment_probability_stack(
-                node, probabilities, "circle"
-            )
-            shapes_lst.extend(prob_shapes)
-            links.extend(prob_links)
+            max_prob = max(probabilities.values())
+            if max_prob < threshold:
+                prob_shapes, prob_links = create_segment_probability_stack(
+                    node, probabilities, "circle"
+                )
+                shapes_lst.extend(prob_shapes)
+                links.extend(prob_links)
+            else:
+                shape_label = get_form_shape_label(node)
+                shape = draw_shape(node.uid, shape_label, "circle")
+                shapes_lst.append(shape)
         else:
             shape_type = "circle" if is_segment_leaf else shapes[node.question.type]
             shape_label = get_form_shape_label(node)

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -129,6 +129,7 @@ def add_segment_notes(
             print("low_conf_label:", low_conf_label)
             use_low_conf = False
             if low_confidence_threshold is not None and node.class_probabilities:
+                low_confidence_threshold = low_confidence_threshold / 100.0
                 max_prob = max(node.class_probabilities.values())
                 print("max_prob:", max_prob, "  type:", type(max_prob))
                 try:

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -105,8 +105,8 @@ def add_segment_notes(
 ) -> Node:
     """Add notes once segments are assigned.
 
-    If confidence_threshold is provided (0.0-1.0), calculate the max probability. If max_probability < threshold,
-    dead-end note will be applied. Otherwise, the segment note is applied.
+    If confidence_threshold is provided (percentage), calculate max probability. If max_probability < threshold,
+    segment + dead-end note will be applied. Otherwise, only segment note is applied.
     """
     low_confidence_threshold = low_confidence_threshold / 100
     new_root = copy.deepcopy(root)

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -129,7 +129,6 @@ def add_segment_notes(
             print("low_conf_label:", low_conf_label)
             use_low_conf = False
             if low_confidence_threshold is not None and node.class_probabilities:
-                low_confidence_threshold = low_confidence_threshold / 100.0
                 max_prob = max(node.class_probabilities.values())
                 print("max_prob:", max_prob, "  type:", type(max_prob))
                 try:

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -120,29 +120,18 @@ def add_segment_notes(
         for key, value in settings_config.items()
         if key.startswith("deadend_note")
     }
+    
     for node in new_root.preorder():
-        # --- DEBUG ROOT: loop reaches here ---
-        print("\nVisiting node:", node)
         if node.is_leaf and node.name == "segment":
-            print(" -> Segment leaf detected")
-            print("class_probabilities:", node.class_probabilities)
-            print("threshold:", low_confidence_threshold)
-            print("low_conf_label:", low_conf_label)
             use_low_conf = False
             if low_confidence_threshold is not None and node.class_probabilities:
                 max_prob = max(node.class_probabilities.values())
-                print("max_prob:", max_prob, "  type:", type(max_prob))
-                try:
-                    print("comparison result:", max_prob < low_confidence_threshold)
-                except Exception as e:
-                    print("comparison error:", e)
                 use_low_conf = max_prob < low_confidence_threshold
-            print("use_low_conf final =", use_low_conf)
             if use_low_conf and low_conf_label:
-                print(" *** APPLYING LOW CONF NOTE ***")
-                add_segment_note(node, low_conf_label, segments_config)
+                # Combine segment note with low confidence note
+                combined_label = {**note_label, **low_conf_label}
+                add_segment_note(node, combined_label, segments_config)
             else:
-                print(" --- applying normal note ---")
                 add_segment_note(node, note_label, segments_config)
 
     return new_root

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -108,6 +108,7 @@ def add_segment_notes(
     If confidence_threshold is provided (0.0-1.0), calculate the max probability. If max_probability < threshold,
     dead-end note will be applied. Otherwise, the segment note is applied.
     """
+    low_confidence_threshold = low_confidence_threshold / 100
     new_root = copy.deepcopy(root)
     note_label = {
         key.replace("segment_note", "label"): value

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -127,15 +127,19 @@ def add_segment_notes(
             if low_confidence_threshold is not None and node.class_probabilities:
                 max_prob = max(node.class_probabilities.values())
                 use_low_conf = max_prob < low_confidence_threshold
-            if use_low_conf and low_conf_label:
-                # Combine segment note with low confidence note
-                combined_label = {**note_label, **low_conf_label}
-                add_segment_note(node, combined_label, segments_config)
-            else:
-                add_segment_note(node, note_label, segments_config)
+            final_label = note_label.copy()
+            if use_low_conf:
+                for key, seg_note in final_label.items():
+                    low_conf_note = low_conf_label.get(
+                        key,
+                        "\n[Low segment assignment confidence]\n"
+                        "We recommend stopping this survey and starting with a new respondent."
+                    )
+                    final_label[key] = seg_note + low_conf_note
+
+            add_segment_note(node, final_label, segments_config)
 
     return new_root
-
 
 def enforce_relevance(root: Node) -> Node:
     """Enforce relevance rules for the node.

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -120,16 +120,30 @@ def add_segment_notes(
         if key.startswith("deadend_note")
     }
     for node in new_root.preorder():
+        # --- DEBUG ROOT: loop reaches here ---
+        print("\nVisiting node:", node)
         if node.is_leaf and node.name == "segment":
+            print(" -> Segment leaf detected")
+            print("class_probabilities:", node.class_probabilities)
+            print("threshold:", low_confidence_threshold)
+            print("low_conf_label:", low_conf_label)
             use_low_conf = False
             if low_confidence_threshold is not None and node.class_probabilities:
                 max_prob = max(node.class_probabilities.values())
+                print("max_prob:", max_prob, "  type:", type(max_prob))
+                try:
+                    print("comparison result:", max_prob < low_confidence_threshold)
+                except Exception as e:
+                    print("comparison error:", e)
                 use_low_conf = max_prob < low_confidence_threshold
-
+            print("use_low_conf final =", use_low_conf)
             if use_low_conf and low_conf_label:
+                print(" *** APPLYING LOW CONF NOTE ***")
                 add_segment_note(node, low_conf_label, segments_config)
             else:
+                print(" --- applying normal note ---")
                 add_segment_note(node, note_label, segments_config)
+
     return new_root
 
 

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -111,12 +111,12 @@ def add_segment_notes(
     low_confidence_threshold = low_confidence_threshold / 100
     new_root = copy.deepcopy(root)
     note_label = {
-        key.replace("segment_note", "label"): value
+        key.replace("segment_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
         for key, value in settings_config.items()
         if key.startswith("segment_note")
     }
     low_conf_label = {
-        key.replace("deadend_note", "label"): value
+        key.replace("deadend_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
         for key, value in settings_config.items()
         if key.startswith("deadend_note")
     }
@@ -308,7 +308,7 @@ def exit_deadends(
 
                 # create note for dead-end
                 deadend_label = {
-                    key.replace("deadend_note", "label"): value
+                    key.replace("deadend_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
                     for key, value in settings_config.items()
                     if key.startswith("deadend_note")
                 }

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -101,7 +101,7 @@ def add_segment_notes(
     root: Node,
     settings_config: dict,
     segments_config: dict | None = None,
-    low_confidence_threshold: float | None = None,
+    low_confidence_threshold: float = 0.0,
 ) -> Node:
     """Add notes once segments are assigned.
 
@@ -124,7 +124,7 @@ def add_segment_notes(
     for node in new_root.preorder():
         if node.is_leaf and node.name == "segment":
             use_low_conf = False
-            if low_confidence_threshold is not None and node.class_probabilities:
+            if low_confidence_threshold > 0 and node.class_probabilities:
                 max_prob = max(node.class_probabilities.values())
                 use_low_conf = max_prob < low_confidence_threshold
             final_label = note_label.copy()

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -101,7 +101,7 @@ def add_segment_notes(
     root: Node,
     settings_config: dict,
     segments_config: dict | None = None,
-    confidence_threshold: float | None = None,
+    low_confidence_threshold: float | None = None,
 ) -> Node:
     """Add notes once segments are assigned.
 
@@ -122,9 +122,9 @@ def add_segment_notes(
     for node in new_root.preorder():
         if node.is_leaf and node.name == "segment":
             use_low_conf = False
-            if confidence_threshold is not None and node.class_probabilities:
+            if low_confidence_threshold is not None and node.class_probabilities:
                 max_prob = max(node.class_probabilities.values())
-                use_low_conf = max_prob < confidence_threshold
+                use_low_conf = max_prob < low_confidence_threshold
 
             if use_low_conf and low_conf_label:
                 add_segment_note(node, low_conf_label, segments_config)


### PR DESCRIPTION
After adding 'threshold' parameter to the pipeline, there are a few changes to note. 

**Form**
**Threshold parameter is set (eg: 70%)**
1. Max Probability < Threshold :
	Present segment note + dead-end note (Low confidence)

<img width="580" height="276" alt="image" src="https://github.com/user-attachments/assets/e4c67916-75b2-42f8-bfb6-05aae97e54d9" />

2. Max Probability > Threshold :
	Present segment note _(Normal Behavior)_
3. Dead-End :
	Assign highest probability segment overall + Dead-end note _(Normal Behavior)_

If threshold parameter is not set, it will default to zero. Therefore, the the low confidence note will not be presented in the first case and case 2 will be the default behavior. (No change happens to dead-ends)
	
**Form Mermaid Diagram**
**Threshold parameter is set (eg: 70%)**
1. Max Probability < Threshold :
	Draw an ordered stack of segment shapes that include the percentages  
2. Max probability > Threshold :
	Present segment without percentage _(Normal Behavior)_
3. Dead-End:
	Draw segment of highest probability overall without percentage _(Normal Behavior)_

<img width="952" height="634" alt="image" src="https://github.com/user-attachments/assets/625a7e22-7430-4a32-a81c-87372db6a8fb" />

If threshold parameter is not set, it will default to zero. Therefore, case 1 will not be implemented and case 2 will be the default behavior. (No change happens to dead-ends) 

**Notes**

- Leaving the threshold empty disables the feature and doesn't raise errors
- PR for typing tool pipelines should be merged first before this one so that the pipeline doesn't crash due to the missing parameter
- [Mermaid Diagram Example](https://whimsical.com/tt-form-threshold-X5T1Ao2bYzVYUtVS83rtbV) with threshold > 70 
- For segment note and dead-end note, this is the excel configuration used in the example
<img width="1165" height="89" alt="image" src="https://github.com/user-attachments/assets/97f4eec6-ed68-4590-8eb2-4396c48779bc" />