### PR TITLE
Feat/mermaid diagram new versions

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -61,7 +61,7 @@ def draw_shape(shape_id: str, label: str, shape_type: ShapeType = "rectangle") -
     return f"{shape_id}{begin}{label}{end}"
 
 def draw_link(shape_a: str, shape_b: str, label: str | None = None, *, dotted: bool = False) -> str:
-    """Print mermaid link between two shapes."""
+    """Print mermaid link between two shapes. Either a straight or dotted link"""
     arrow_style = "-.->" if dotted else "-->"
     if label:
         label = clean_label(label)
@@ -146,10 +146,17 @@ def get_form_link_label(node: Node, language: str = "English (en)") -> str:
 def create_segment_probability_stack(
     node: Node, probabilities: dict[str, float], shape_type: str = "stadium", *, low_confidence: bool = False
 ) -> tuple[list[str], list[str]]:
-    """Create stacked shapes and links for segment probabilities.
+    """
+    Create stacked shapes and links for segment probabilities.
+
+    Args:
+        node (Node): The node representing the segment.
+        probabilities (dict[str, float]): Probabilities for each segment.
+        shape_type (str): The shape type to use for the stack (default: "stadium").
+        low_confidence (bool): If True, marks shapes/links as low confidence (default: False).
 
     Returns:
-        tuple: (list of shapes, list of links between shapes)
+        tuple[list[str], list[str]]: (list of shape strings, list of link strings)
     """
     shapes = []
     links = []
@@ -180,7 +187,17 @@ def create_segment_probability_stack(
     return shapes, links
 
 def create_default_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
-    """Create simple mermaid diagram for typing form."""
+    """
+    Create a simple mermaid diagram for a typing form tree.
+
+    Args:
+        root (Node): The root node of the form tree.
+        skip_notes (bool): If True, skip nodes of type "note" (default: False).
+        threshold (float): Probability threshold for low confidence (default: 0.0, as percent).
+
+    Returns:
+        str: Mermaid diagram as a string.
+    """
     header = "flowchart TD"
     threshold = threshold / 100.0
     shapes_lst = []
@@ -219,7 +236,17 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
 
 
 def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
-    """Create detailed mermaid diagram with stacked probabilities for typing form."""
+    """
+    Create a detailed mermaid diagram with stacked probabilities for a typing form tree.
+
+    Args:
+        root (Node): The root node of the form tree.
+        skip_notes (bool): If True, skip nodes of type "note" (default: False).
+        threshold (float): Probability threshold for low confidence (default: 0.0, as percent).
+
+    Returns:
+        str: Mermaid diagram as a string.
+    """
     header = "flowchart TD"
     threshold = threshold / 100.0
     shapes_lst = []

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -173,7 +173,7 @@ def create_segment_probability_stack(
 
     return shapes, links
 
-
+# Default TT diagram function
 def create_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
     """Create mermaid diagram for typing form."""
     header = "flowchart TD"
@@ -200,16 +200,11 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False, threshold: floa
 
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
+            shape_label = get_form_shape_label(node)
             if max_prob < threshold:
-                prob_shapes, prob_links = create_segment_probability_stack(
-                    node, probabilities, "circle"
-                )
-                shapes_lst.extend(prob_shapes)
-                links.extend(prob_links)
-            else:
-                shape_label = get_form_shape_label(node)
-                shape = draw_shape(node.uid, shape_label, "circle")
-                shapes_lst.append(shape)
+                shape_label = f"(*) {shape_label}"  
+            shape = draw_shape(node.uid, shape_label, "circle")
+            shapes_lst.append(shape)
         else:
             shape_type = "circle" if is_segment_leaf else shapes[node.question.type]
             shape_label = get_form_shape_label(node)

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -26,6 +26,17 @@ ShapeType = Literal[
     "rhombus",
 ]
 
+FORM_SHAPE_TYPES = {
+    "segment": "stadium",
+    "select_one": "rectangle",
+    "select_multiple": "rectangle",
+    "calculate": "parallelogram",
+    "integer": "trapezoid",
+    "decimal": "trapezoid_alt",
+    "text": "circle",
+    "note": "parallelogram_alt",
+}
+
 
 def clean_label(label: str) -> str:
     """Clean label string to not break whimsical import."""
@@ -153,6 +164,7 @@ def create_segment_probability_stack(
         return shapes, links
     items.sort(key=lambda x: x[1], reverse=True)
 
+    # Top row (highest probability)
     prefix = "* " if low_confidence else ""
     prev_id = node.uid
     top_seg, top_prob = items[0]
@@ -160,6 +172,7 @@ def create_segment_probability_stack(
     top_shape = draw_shape(prev_id, top_label, shape_type)
     shapes.append(top_shape)
 
+    # Remaining rows (lower probabilities)
     for i, (seg, prob) in enumerate(items[1:], start=2):
         new_id = f"{node.uid}_prob_{i}"
         new_label = f"{prefix}{seg} ({prob * 100:.0f}%)"
@@ -176,17 +189,6 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
     """Create simple mermaid diagram for typing form."""
     header = "flowchart TD"
     threshold = threshold / 100.0
-    shapes = {
-        "segment": "stadium",
-        "select_one": "rectangle",
-        "select_multiple": "rectangle",
-        "calculate": "parallelogram",
-        "integer": "trapezoid",
-        "decimal": "trapezoid_alt",
-        "text": "circle",
-        "note": "parallelogram_alt",
-    }
-
     shapes_lst = []
     links = []
     for node in root.preorder():
@@ -204,7 +206,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
             shape = draw_shape(node.uid, shape_label, "circle")
             shapes_lst.append(shape)
         else:
-            shape_type = "circle" if is_segment_leaf else shapes[node.question.type]
+            shape_type = "circle" if is_segment_leaf else FORM_SHAPE_TYPES[node.question.type]
             shape_label = get_form_shape_label(node)
             shape = draw_shape(node.uid, shape_label, shape_type)
             shapes_lst.append(shape)
@@ -222,17 +224,6 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
     """Create detailed mermaid diagram with stacked probabilities for typing form."""
     header = "flowchart TD"
     threshold = threshold / 100.0
-    shapes = {
-        "segment": "stadium",
-        "select_one": "rectangle",
-        "select_multiple": "rectangle",
-        "calculate": "parallelogram",
-        "integer": "trapezoid",
-        "decimal": "trapezoid_alt",
-        "text": "circle",
-        "note": "parallelogram_alt",
-    }
-
     shapes_lst = []
     links = []
     for node in root.preorder():
@@ -250,7 +241,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
             shapes_lst.extend(prob_shapes)
             links.extend(prob_links)
         else:
-            shape_type = "circle" if is_segment_leaf else shapes[node.question.type]
+            shape_type = "circle" if is_segment_leaf else FORM_SHAPE_TYPES[node.question.type]
             shape_label = get_form_shape_label(node)
             shape = draw_shape(node.uid, shape_label, shape_type)
             shapes_lst.append(shape)

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -159,7 +159,7 @@ def create_segment_probability_stack(
     items.sort(key=lambda x: x[1], reverse=True)
 
     # Top row (highest probability)
-    prefix = "<b>*</b>" if low_confidence else ""
+    prefix = "*" if low_confidence else ""
     prev_id = node.uid
     top_seg, top_prob = items[0]
     top_label = f"{prefix}{top_seg} ({top_prob * 100:.0f}%)"
@@ -199,7 +199,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
 
             shape_label = get_form_shape_label(node)
             if is_low_confidence:
-                shape_label = f"<b>*</b>{shape_label}"  
+                shape_label = f"*{shape_label}"  
             shape = draw_shape(node.uid, shape_label, "circle")
             shapes_lst.append(shape)
         else:

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -202,7 +202,7 @@ def create_form_diagram(root: Node, *, skip_notes: bool = False, threshold: floa
             max_prob = max(probabilities.values())
             shape_label = get_form_shape_label(node)
             if max_prob < threshold:
-                shape_label = f"(*) {shape_label}"  
+                shape_label = f"* {shape_label}"  
             shape = draw_shape(node.uid, shape_label, "circle")
             shapes_lst.append(shape)
         else:

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -106,7 +106,7 @@ def add_segment_notes(
     """Add notes once segments are assigned.
 
     If confidence_threshold is provided (percentage), calculate max probability. If max_probability < threshold,
-    segment + dead-end note will be applied. Otherwise, only segment note is applied.
+    segment + low confidence note will be applied. Otherwise, only segment note is applied.
     """
     low_confidence_threshold = low_confidence_threshold / 100
     new_root = copy.deepcopy(root)

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -116,9 +116,9 @@ def add_segment_notes(
         if key.startswith("segment_note")
     }
     low_conf_label = {
-        key.replace("deadend_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
+        key.replace("low_confidence_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
         for key, value in settings_config.items()
-        if key.startswith("deadend_note")
+        if key.startswith("low_confidence_note")
     }
     
     for node in new_root.preorder():
@@ -306,16 +306,16 @@ def exit_deadends(
                 }
                 label = {key: value.format(segment=segment) for key, value in note_label.items()}
 
-                # create note for dead-end
-                deadend_label = {
-                    key.replace("deadend_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
+                # create note for low confidence
+                low_confidence_label = {
+                    key.replace("low_confidence_note", "label"): value.replace("\\n", "\n") if isinstance(value, str) else value
                     for key, value in settings_config.items()
-                    if key.startswith("deadend_note")
+                    if key.startswith("low_confidence_note")
                 }
 
                 for key in label:
-                    if key in deadend_label:
-                        label[key] += deadend_label[key]
+                    if key in low_confidence_label:
+                        label[key] += low_confidence_label[key]
                     else:
                         label[key] += (
                             "\n[Low segment assignment confidence]\nWe recommend stopping this survey and starting with a new respondent."


### PR DESCRIPTION
**Firstly**, there are now two functions that create different  versions of the form diagram:

- Default Form Diagram - Has no confidence percentages + low confidence warning on segments below threshold
- Detailed Form Diagram - Has confidence percentages for all nodes + low confidence warning on segments below threshold
- For low confidence nodes, they are marked by an asterisk in the label in both diagrams

[Jira Ticket ](https://bluesquare.atlassian.net/browse/PATHWAYS-1117)

Diagrams generated during testing using Indonesia TT:
- [Default Form Diagram](https://whimsical.com/tt-default-diagram-5t96UBLv4i9QRnJj4DyRef)
- [Detailed Form Diagram](https://whimsical.com/tt-detailed-diagram-QRUF9MTXrSVtbYUiWv3a1T)

The output syntax includes dotted lines when pointing to a low confidence node. Dotted lines are not supported in whimsical but can be viewed using draw.io -> [Detailed Form Diagram](https://drive.google.com/file/d/1fkReJDlvy5FW3kJWLmNGu51pHTkq782w/view?usp=sharing)

Open using draw.io 

<img width="400" height="570" alt="image" src="https://github.com/user-attachments/assets/2e1b20a6-c437-4ca0-9d85-dc5b00c384db" />

**Secondly**, adjustments were made in `options.py` to change `deadend_note` to `low_confidence_note`. This should also be updated in the excel file source for each country. [Indonesia Form Configuration](https://docs.google.com/spreadsheets/d/1OasNkaiwE03YFGkttN3YjgniZtnNGr22ZF76Y-F-UxQ/edit?gid=597352189#gid=597352189).

Required Changes

<img width="287" height="66" alt="image" src="https://github.com/user-attachments/assets/4e96f577-2a5a-497a-86e8-0f7c879af234" />

This PR should be merged after this one to update the pipeline - [PR](https://github.com/BLSQ/pathways-typing-pipelines/pull/2)