### PR TITLE
fix: Use segment names instead of cluster codes in detailed mermaid d…

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -83,8 +83,7 @@ def build_cluster_to_node_mapping(root: Node) -> dict[str, Node]:
     """Build a mapping from cluster name to Node."""
     mapping = {}
     for node in root.preorder():
-        if hasattr(node, "cart") and hasattr(node.cart, "cluster"):
-            mapping[node.cart.cluster] = node
+        mapping[node.cart.cluster] = node
     return mapping
 
 def create_cart_diagram(root: Node) -> str:

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -83,7 +83,8 @@ def build_cluster_to_node_mapping(root: Node) -> dict[str, Node]:
     """Build a mapping from cluster name to Node."""
     mapping = {}
     for node in root.preorder():
-        mapping[node.cart.cluster] = node
+        if hasattr(node, "cart") and hasattr(node.cart, "cluster"):
+            mapping[node.cart.cluster] = node
     return mapping
 
 def create_cart_diagram(root: Node) -> str:


### PR DESCRIPTION
**Issue**
The detailed diagram does not use the segment names but the cluster names from the form configuration
<img width="640" height="419" alt="image" src="https://github.com/user-attachments/assets/2afd3aef-9ba5-4b43-9d11-2c1bba6fc7fc" />


**Solution**
In the default diagram, the code always has the node for each segment, so it can easily show the correct segment name. But in the detailed (stacked) diagram, the code only has clusters (like "U1", "U2") extracted from the probabilities dictionary, not the actual node. To get the right segment name that is mapped in the form configuration for each cluster, the code builds a mapping from cluster name to node. This lets the diagram show the same segment names as the default diagram, instead of the cluster name.

This adds to the complexity of the code a bit but I see no way around it. Another approach was to hard code a dictionary with the mapping from cluster to segment name  and use that instead but then this could be error-prone if the configuration changed but not reflected in the dictionary.

**Testing**
<img width="1050" height="828" alt="image" src="https://github.com/user-attachments/assets/cd78c359-9a55-4b36-b5be-1d0f4840afc1" />