### PR TITLE
Fix/threshold precision

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -190,7 +190,7 @@ def create_segment_probability_stack(
         segment_label = get_form_shape_label(cluster_to_node[top_seg], language)
     else:
         segment_label = top_seg
-    top_label = f"{prefix}{segment_label} ({top_prob * 100:.1f}%)"
+    top_label = f"{prefix}{segment_label} ({top_prob * 100:.2f}%)"
     top_shape = draw_shape(prev_id, top_label, shape_type)
     shapes.append(top_shape)
 
@@ -201,7 +201,7 @@ def create_segment_probability_stack(
             segment_label = get_form_shape_label(cluster_to_node[seg], language)
         else:
             segment_label = seg
-        new_label = f"{prefix}{segment_label} ({prob * 100:.1f}%)"
+        new_label = f"{prefix}{segment_label} ({prob * 100:.2f}%)"
         new_shape = draw_shape(new_id, new_label, shape_type)
         shapes.append(new_shape)
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -190,7 +190,7 @@ def create_segment_probability_stack(
         segment_label = get_form_shape_label(cluster_to_node[top_seg], language)
     else:
         segment_label = top_seg
-    top_label = f"{prefix}{segment_label} ({top_prob * 100:.2f}%)"
+    top_label = f"{prefix}{segment_label} ({top_prob * 100:.1f}%)"
     top_shape = draw_shape(prev_id, top_label, shape_type)
     shapes.append(top_shape)
 
@@ -201,7 +201,7 @@ def create_segment_probability_stack(
             segment_label = get_form_shape_label(cluster_to_node[seg], language)
         else:
             segment_label = seg
-        new_label = f"{prefix}{segment_label} ({prob * 100:.2f}%)"
+        new_label = f"{prefix}{segment_label} ({prob * 100:.1f}%)"
         new_shape = draw_shape(new_id, new_label, shape_type)
         shapes.append(new_shape)
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -224,7 +224,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold = float(threshold) / 100.0
+    threshold_pct = float(threshold)
     shapes_lst = []
     links = []
     for node in root.preorder():
@@ -237,7 +237,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
+            is_low_confidence = round(max_prob * 100, 2) < round(threshold_pct, 2)
 
             shape_label = get_form_shape_label(node)
             if is_low_confidence:
@@ -273,7 +273,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold = float(threshold) / 100.0
+    threshold_pct = float(threshold)
     shapes_lst = []
     links = []
     cluster_to_node = build_cluster_to_node_mapping(root)
@@ -287,7 +287,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
+            is_low_confidence = round(max_prob * 100, 2) < round(threshold_pct, 2)
 
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "circle", low_confidence=is_low_confidence, cluster_to_node=cluster_to_node

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -224,7 +224,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold = threshold / 100.0
+    threshold = float(threshold) / 100.0
     shapes_lst = []
     links = []
     for node in root.preorder():
@@ -237,7 +237,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = max_prob < threshold
+            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
 
             shape_label = get_form_shape_label(node)
             if is_low_confidence:
@@ -273,7 +273,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold = threshold / 100.0
+    threshold = float(threshold) / 100.0
     shapes_lst = []
     links = []
     cluster_to_node = build_cluster_to_node_mapping(root)
@@ -287,7 +287,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = max_prob < threshold
+            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
 
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "circle", low_confidence=is_low_confidence, cluster_to_node=cluster_to_node

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -224,7 +224,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold_pct = float(threshold)
+    threshold = float(threshold) / 100.0
     shapes_lst = []
     links = []
     for node in root.preorder():
@@ -237,7 +237,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = round(max_prob * 100, 2) < round(threshold_pct, 2)
+            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
 
             shape_label = get_form_shape_label(node)
             if is_low_confidence:
@@ -273,7 +273,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold_pct = float(threshold)
+    threshold = float(threshold) / 100.0
     shapes_lst = []
     links = []
     cluster_to_node = build_cluster_to_node_mapping(root)
@@ -287,7 +287,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = round(max_prob * 100, 2) < round(threshold_pct, 2)
+            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
 
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "circle", low_confidence=is_low_confidence, cluster_to_node=cluster_to_node

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -190,7 +190,7 @@ def create_segment_probability_stack(
         segment_label = get_form_shape_label(cluster_to_node[top_seg], language)
     else:
         segment_label = top_seg
-    top_label = f"{prefix}{segment_label} ({top_prob * 100:.0f}%)"
+    top_label = f"{prefix}{segment_label} ({top_prob * 100:.1f}%)"
     top_shape = draw_shape(prev_id, top_label, shape_type)
     shapes.append(top_shape)
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -201,7 +201,7 @@ def create_segment_probability_stack(
             segment_label = get_form_shape_label(cluster_to_node[seg], language)
         else:
             segment_label = seg
-        new_label = f"{prefix}{segment_label} ({prob * 100:.0f}%)"
+        new_label = f"{prefix}{segment_label} ({prob * 100:.1f}%)"
         new_shape = draw_shape(new_id, new_label, shape_type)
         shapes.append(new_shape)
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -224,7 +224,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold = float(threshold) / 100.0
+    threshold = threshold / 100.0
     shapes_lst = []
     links = []
     for node in root.preorder():
@@ -237,7 +237,7 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
+            is_low_confidence = max_prob < threshold
 
             shape_label = get_form_shape_label(node)
             if is_low_confidence:
@@ -273,7 +273,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         str: Mermaid diagram as a string.
     """
     header = "flowchart TD"
-    threshold = float(threshold) / 100.0
+    threshold = threshold / 100.0
     shapes_lst = []
     links = []
     cluster_to_node = build_cluster_to_node_mapping(root)
@@ -287,7 +287,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         
         if is_segment_leaf and probabilities:
             max_prob = max(probabilities.values())
-            is_low_confidence = round(max_prob, 6) < round(threshold, 6)
+            is_low_confidence = max_prob < threshold
 
             prob_shapes, prob_links = create_segment_probability_stack(
                 node, probabilities, "circle", low_confidence=is_low_confidence, cluster_to_node=cluster_to_node


### PR DESCRIPTION
**Issue**
Mermaid diagram was marking some nodes as having low probability when it shouldn't

**Cause**
Probability labels were formatted as whole percentages.
For example:
- 79.8% was rounded to 80%
- 38.4% was rounded to 38%
This rounding could make a node appear more or less confident than it actually was

**Change**
Updated the label formatting to display probabilities with one decimal place (e.g. 79.8%, 38.4%).
<img width="573" height="316" alt="image" src="https://github.com/user-attachments/assets/ab40429b-f75d-407a-a33e-50a250b36cb1" />