### PR TITLE
Fix/threshold precision

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -11,6 +11,7 @@ Notes
 """
 
 from typing import Literal
+import math
 
 from .exceptions import MermaidError
 from .tree import Node, filter_choices
@@ -190,7 +191,9 @@ def create_segment_probability_stack(
         segment_label = get_form_shape_label(cluster_to_node[top_seg], language)
     else:
         segment_label = top_seg
-    top_label = f"{prefix}{segment_label} ({top_prob * 100:.2f}%)"
+    top_percentage = top_prob * 100
+    top_truncated = math.floor(top_percentage * 10) / 10.0
+    top_label = f"{prefix}{segment_label} ({top_truncated:.1f}%)"
     top_shape = draw_shape(prev_id, top_label, shape_type)
     shapes.append(top_shape)
 
@@ -201,7 +204,9 @@ def create_segment_probability_stack(
             segment_label = get_form_shape_label(cluster_to_node[seg], language)
         else:
             segment_label = seg
-        new_label = f"{prefix}{segment_label} ({prob * 100:.2f}%)"
+        new_percentage = prob * 100
+        new_truncated = math.floor(new_percentage * 10) / 10.0
+        new_label = f"{prefix}{segment_label} ({new_truncated:.1f}%)"
         new_shape = draw_shape(new_id, new_label, shape_type)
         shapes.append(new_shape)
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -190,7 +190,7 @@ def create_segment_probability_stack(
         segment_label = get_form_shape_label(cluster_to_node[top_seg], language)
     else:
         segment_label = top_seg
-    top_label = f"{prefix}{segment_label} ({top_prob * 100:.1f}%)"
+    top_label = f"{prefix}{segment_label} ({top_prob * 100:.2f}%)"
     top_shape = draw_shape(prev_id, top_label, shape_type)
     shapes.append(top_shape)
 
@@ -201,7 +201,7 @@ def create_segment_probability_stack(
             segment_label = get_form_shape_label(cluster_to_node[seg], language)
         else:
             segment_label = seg
-        new_label = f"{prefix}{segment_label} ({prob * 100:.1f}%)"
+        new_label = f"{prefix}{segment_label} ({prob * 100:.2f}%)"
         new_shape = draw_shape(new_id, new_label, shape_type)
         shapes.append(new_shape)
 


### PR DESCRIPTION
**Issue**
The previous change formatted probabilities in the diagram by rounding to one decimal place.
This introduced an edge case near the confidence threshold.
For example:
Threshold: 68%
Actual probability: 67.96%

When rounded to one decimal place, 67.96% became 68.0% in the diagram.
However, internally the value (0.6796) is still less than the threshold (0.68), so the node was correctly marked as low confidence.

This created a mismatch where the diagram displayed 68.0%, but the node was flagged as low confidence, which appeared inconsistent.

**Fix**
Instead of rounding, probabilities are now truncated to one decimal place before being displayed.
Example:
67.96% → 67.9%

[Jira Ticket ](https://bluesquare.atlassian.net/browse/PATHWAYS-1117)