### PR TITLE
Display choices edgecase nodes

### DIFF
--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -10,6 +10,7 @@ Notes
       feature.
 """
 
+from platform import node
 from typing import Literal
 import math
 
@@ -133,43 +134,46 @@ def get_form_shape_label(node: Node, language: str = "English (en)") -> str:
 
 def get_form_link_label(node: Node, choices_config: dict, language: str = "English (en)") -> str:
     """Get label for form link between current node and its parent."""
-    # Case 1: explicit choices
+    # Normal Case
     if node.question.choices_from_parent:
-        labels = [
-            choice.label[f"label::{language}"]
-            for choice in node.question.choices_from_parent
+        choices = [
+            choice.label[f"label::{language}"] for choice in node.question.choices_from_parent
         ]
-        return ", ".join(labels)
-    # Case 2: no rule
-    if not node.cart_rule:
-        return ""
-    normalized_var = node.cart_rule.var.replace(".", "_").lower()
-    # Case 3: config lookup
-    if normalized_var in choices_config:
-        try:
-            choices = [
-                Choice(
-                    list_name=choice["choice_list"],
-                    name=choice["name"],
-                    label={k: v for k, v in choice.items() if k.startswith("label")},
-                    cart_value=choice.get("target_value"),
-                )
-                for choice in choices_config[normalized_var]
-            ]
-            filtered = filter_choices(choices, node.cart_rule)
-            if filtered:
-                labels = [
-                    choice.label[f"label::{language}"]
-                    for choice in filtered
-                ]
+        return ", ".join([str(choice) for choice in choices])
+    
+    # Calculate Nodes
+    if node.parent.question.type == "calculate" and node.cart_rule:
+        normalized_var = node.cart_rule.var.replace(".", "_").lower()
+        for parent in node.parents:
+            if parent.name == normalized_var:
+                # if no choices on node, try Excel config
+                if not parent.question.choices:
+                    if normalized_var in choices_config:
+                        choices = [
+                            Choice(
+                                list_name=choice["choice_list"],
+                                name=choice["name"],
+                                label={k: v for k, v in choice.items() if k.startswith("label")},
+                                cart_value=choice.get("target_value"),
+                            )
+                            for choice in choices_config[normalized_var]
+                        ]
+                        filtered = filter_choices(choices, node.cart_rule)
+                        if filtered:
+                            labels = [
+                                choice.label[f"label::{language}"]
+                                for choice in filtered
+                            ]
+                            return ", ".join(labels)
+                    return ""
+                choices = filter_choices(parent.question.choices, node.cart_rule)
+                labels = [choice.label[f"label::{language}"] for choice in choices]
                 return ", ".join(labels)
-        except (TypeError, ValueError, AttributeError):
-            pass
-    # Case 4: in operator
-    if node.cart_rule.operator == "in":
-        return ", ".join(node.cart_rule.value)
-    # Case 5: fallback rule
-    return f"{node.cart_rule.operator} {node.cart_rule.value}"
+    
+    if node.parent.question.type == "calculate" and node.cart_rule:
+        return f"'{node.cart_rule.operator} {node.cart_rule.value}'"
+
+    return ""
 
 def create_segment_probability_stack(
     node: Node,

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -14,7 +14,7 @@ from typing import Literal
 import math
 
 from .exceptions import MermaidError
-from .tree import Node, filter_choices
+from .tree import Node, filter_choices, Choice
 
 ShapeType = Literal[
     "rectangle",
@@ -131,34 +131,64 @@ def get_form_shape_label(node: Node, language: str = "English (en)") -> str:
         return label
     return node.name
 
-def get_form_link_label(node: Node, language: str = "English (en)") -> str:
+def get_form_link_label(node: Node, choices_config: dict, language: str = "English (en)") -> str:
     """Get label for form link between current node and its parent."""
-    # Case 1: Normal Question Nodes
+    # Case 1: explicit choices
     if node.question.choices_from_parent:
-        choices = [
-            choice.label[f"label::{language}"] 
+        labels = [
+            choice.label[f"label::{language}"]
             for choice in node.question.choices_from_parent
         ]
-        return ", ".join([str(choice) for choice in choices])
-    # Case 2: Calculate Nodes
-    if node.parent.question.type == "calculate" and node.cart_rule:
-        normalized_var = node.cart_rule.var.replace(".", "_").lower()
-        for parent in node.parents:
-            if not parent.question:
-                continue
-            parent_var = parent.name.rsplit("_", 1)[0].replace(".", "_").lower()
-            if parent_var == normalized_var:
-                if not parent.question.choices:
-                    return ""
+        return ", ".join(labels)
+    # Case 2: no rule
+    if not node.cart_rule:
+        return ""
+    normalized_var = node.cart_rule.var.replace(".", "_").lower()
+    # Case 3: ancestor search
+    for parent in node.parents:
+        if not parent.question:
+            continue
+        parent_var = parent.name.replace(".", "_").lower()
+        # skip categorical variants
+        if parent_var.endswith("_cat"):
+            continue
+        if parent_var == normalized_var and parent.question.choices:
+            try:
                 choices = filter_choices(parent.question.choices, node.cart_rule)
+                if choices:
+                    labels = [
+                        choice.label[f"label::{language}"]
+                        for choice in choices
+                    ]
+                    return ", ".join(labels)
+            except (TypeError, ValueError, AttributeError):
+                continue
+    # Case 4: config lookup
+    if normalized_var in choices_config:
+        try:
+            choices = [
+                Choice(
+                    list_name=choice["choice_list"],
+                    name=choice["name"],
+                    label={k: v for k, v in choice.items() if k.startswith("label")},
+                    cart_value=choice.get("target_value"),
+                )
+                for choice in choices_config[normalized_var]
+            ]
+            filtered = filter_choices(choices, node.cart_rule)
+            if filtered:
                 labels = [
-                    choice.label[f"label::{language}"] 
-                    for choice in choices
+                    choice.label[f"label::{language}"]
+                    for choice in filtered
                 ]
                 return ", ".join(labels)
-        # Fallback 
-        return f"'{node.cart_rule.operator} {node.cart_rule.value}'"
-    return ""
+        except (TypeError, ValueError, AttributeError):
+            pass
+    # Case 5: in operator
+    if node.cart_rule.operator == "in":
+        return ", ".join(node.cart_rule.value)
+    # Case 6: fallback rule
+    return f"{node.cart_rule.operator} {node.cart_rule.value}"
 
 def create_segment_probability_stack(
     node: Node,
@@ -223,12 +253,13 @@ def create_segment_probability_stack(
 
     return shapes, links
 
-def create_default_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
+def create_default_form_diagram(root: Node, choices_config: dict, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
     """
     Create a simple mermaid diagram for a typing form tree.
 
     Args:
         root (Node): The root node of the form tree.
+        choices_config (dict): Choices configuration from Excel.
         skip_notes (bool): If True, skip nodes of type "note" (default: False).
         threshold (float): Probability threshold for low confidence (default: 0.0, as percent).
 
@@ -265,19 +296,20 @@ def create_default_form_diagram(root: Node, *, skip_notes: bool = False, thresho
         if node.is_root:
             continue
 
-        link_label = get_form_link_label(node)
+        link_label = get_form_link_label(node, choices_config)
         link = draw_link(node.parent.question.name, node.question.name, link_label, dotted=is_low_confidence)
         links.append(link)
 
     return "\n\t".join([header, *shapes_lst, *links])
 
 
-def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
+def create_detailed_form_diagram(root: Node, choices_config: dict, *, skip_notes: bool = False, threshold: float = 0.0) -> str:
     """
     Create a detailed mermaid diagram with stacked probabilities for a typing form tree.
 
     Args:
         root (Node): The root node of the form tree.
+        choices_config (dict): Choices configuration from Excel.
         skip_notes (bool): If True, skip nodes of type "note" (default: False).
         threshold (float): Probability threshold for low confidence (default: 0.0, as percent).
 
@@ -315,7 +347,7 @@ def create_detailed_form_diagram(root: Node, *, skip_notes: bool = False, thresh
         if node.is_root:
             continue
 
-        link_label = get_form_link_label(node)
+        link_label = get_form_link_label(node, choices_config)
         link = draw_link(node.parent.question.name, node.question.name, link_label, dotted=is_low_confidence)
         links.append(link)
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -133,24 +133,31 @@ def get_form_shape_label(node: Node, language: str = "English (en)") -> str:
 
 def get_form_link_label(node: Node, language: str = "English (en)") -> str:
     """Get label for form link between current node and its parent."""
+    # Case 1: Normal Question Nodes
     if node.question.choices_from_parent:
         choices = [
-            choice.label[f"label::{language}"] for choice in node.question.choices_from_parent
+            choice.label[f"label::{language}"] 
+            for choice in node.question.choices_from_parent
         ]
         return ", ".join([str(choice) for choice in choices])
-
+    # Case 2: Calculate Nodes
     if node.parent.question.type == "calculate" and node.cart_rule:
+        normalized_var = node.cart_rule.var.replace(".", "_").lower()
         for parent in node.parents:
-            if parent.name == node.cart_rule.var.replace(".", "_").lower():
+            if not parent.question:
+                continue
+            parent_var = parent.name.rsplit("_", 1)[0].replace(".", "_").lower()
+            if parent_var == normalized_var:
                 if not parent.question.choices:
                     return ""
                 choices = filter_choices(parent.question.choices, node.cart_rule)
-                labels = [choice.label[f"label::{language}"] for choice in choices]
+                labels = [
+                    choice.label[f"label::{language}"] 
+                    for choice in choices
+                ]
                 return ", ".join(labels)
-
-    if node.parent.question.type == "calculate" and node.cart_rule:
+        # Fallback 
         return f"'{node.cart_rule.operator} {node.cart_rule.value}'"
-
     return ""
 
 def create_segment_probability_stack(

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -134,21 +134,23 @@ def get_form_shape_label(node: Node, language: str = "English (en)") -> str:
 
 def get_form_link_label(node: Node, choices_config: dict, language: str = "English (en)") -> str:
     """Get label for form link between current node and its parent."""
-    # Normal Case
+    # Normal Nodes
     if node.question.choices_from_parent:
         choices = [
             choice.label[f"label::{language}"] for choice in node.question.choices_from_parent
         ]
         return ", ".join([str(choice) for choice in choices])
-    
+
     # Calculate Nodes
     if node.parent.question.type == "calculate" and node.cart_rule:
         normalized_var = node.cart_rule.var.replace(".", "_").lower()
         for parent in node.parents:
+            if not parent.question:
+                continue
             if parent.name == normalized_var:
-                # if no choices on node, try Excel config
+                # Try Excel config if node has no choices
                 if not parent.question.choices:
-                    if normalized_var in choices_config:
+                    if normalized_var in choices_config and choices_config[normalized_var]:
                         choices = [
                             Choice(
                                 list_name=choice["choice_list"],
@@ -158,17 +160,19 @@ def get_form_link_label(node: Node, choices_config: dict, language: str = "Engli
                             )
                             for choice in choices_config[normalized_var]
                         ]
-                        filtered = filter_choices(choices, node.cart_rule)
+                        filtered = filter_choices(choices, node.cart_rule) 
                         if filtered:
                             labels = [
                                 choice.label[f"label::{language}"]
-                                for choice in filtered
-                            ]
+                                for choice in filtered]
                             return ", ".join(labels)
-                choices = filter_choices(parent.question.choices, node.cart_rule)
-                labels = [choice.label[f"label::{language}"] for choice in choices]
-                return ", ".join(labels)
-    # Falback
+                else:
+                    choices = filter_choices(parent.question.choices, node.cart_rule) 
+                    labels = [
+                        choice.label[f"label::{language}"]
+                        for choice in choices]
+                    return ", ".join(labels)
+    # Fallback
     if node.parent.question.type == "calculate" and node.cart_rule:
         return f"'{node.cart_rule.operator} {node.cart_rule.value}'"
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -174,7 +174,7 @@ def get_form_link_label(node: Node, choices_config: dict, language: str = "Engli
                     return ", ".join(labels)
     # Fallback
     if node.parent.question.type == "calculate" and node.cart_rule:
-        return f"'{node.cart_rule.operator} {node.cart_rule.value}'"
+        return f"{node.cart_rule.operator} {node.cart_rule.value}"
 
     return ""
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -165,11 +165,10 @@ def get_form_link_label(node: Node, choices_config: dict, language: str = "Engli
                                 for choice in filtered
                             ]
                             return ", ".join(labels)
-                    return ""
                 choices = filter_choices(parent.question.choices, node.cart_rule)
                 labels = [choice.label[f"label::{language}"] for choice in choices]
                 return ", ".join(labels)
-    
+    # Falback
     if node.parent.question.type == "calculate" and node.cart_rule:
         return f"'{node.cart_rule.operator} {node.cart_rule.value}'"
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -284,7 +284,7 @@ def create_default_form_diagram(root: Node, choices_config: dict, *, skip_notes:
             continue
 
         link_label = get_form_link_label(node, choices_config)
-        link = draw_link(node.parent.uid, node.uid, link_label, dotted=is_low_confidence)
+        link = draw_link(node.parent.question.name, node.question.name, link_label, dotted=is_low_confidence)
         links.append(link)
 
     return "\n\t".join([header, *shapes_lst, *links])
@@ -335,7 +335,7 @@ def create_detailed_form_diagram(root: Node, choices_config: dict, *, skip_notes
             continue
 
         link_label = get_form_link_label(node, choices_config)
-        link = draw_link(node.parent.uid, node.uid, link_label, dotted=is_low_confidence)
+        link = draw_link(node.parent.question.name, node.question.name, link_label, dotted=is_low_confidence)
         links.append(link)
 
     return "\n\t".join([header, *shapes_lst, *links])

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -144,26 +144,7 @@ def get_form_link_label(node: Node, choices_config: dict, language: str = "Engli
     if not node.cart_rule:
         return ""
     normalized_var = node.cart_rule.var.replace(".", "_").lower()
-    # Case 3: ancestor search
-    for parent in node.parents:
-        if not parent.question:
-            continue
-        parent_var = parent.name.replace(".", "_").lower()
-        # skip categorical variants
-        if parent_var.endswith("_cat"):
-            continue
-        if parent_var == normalized_var and parent.question.choices:
-            try:
-                choices = filter_choices(parent.question.choices, node.cart_rule)
-                if choices:
-                    labels = [
-                        choice.label[f"label::{language}"]
-                        for choice in choices
-                    ]
-                    return ", ".join(labels)
-            except (TypeError, ValueError, AttributeError):
-                continue
-    # Case 4: config lookup
+    # Case 3: config lookup
     if normalized_var in choices_config:
         try:
             choices = [
@@ -184,10 +165,10 @@ def get_form_link_label(node: Node, choices_config: dict, language: str = "Engli
                 return ", ".join(labels)
         except (TypeError, ValueError, AttributeError):
             pass
-    # Case 5: in operator
+    # Case 4: in operator
     if node.cart_rule.operator == "in":
         return ", ".join(node.cart_rule.value)
-    # Case 6: fallback rule
+    # Case 5: fallback rule
     return f"{node.cart_rule.operator} {node.cart_rule.value}"
 
 def create_segment_probability_stack(

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -10,7 +10,6 @@ Notes
       feature.
 """
 
-from platform import node
 from typing import Literal
 import math
 

--- a/pathways/typing/mermaid.py
+++ b/pathways/typing/mermaid.py
@@ -278,7 +278,7 @@ def create_default_form_diagram(root: Node, choices_config: dict, *, skip_notes:
             continue
 
         link_label = get_form_link_label(node, choices_config)
-        link = draw_link(node.parent.question.name, node.question.name, link_label, dotted=is_low_confidence)
+        link = draw_link(node.parent.uid, node.uid, link_label, dotted=is_low_confidence)
         links.append(link)
 
     return "\n\t".join([header, *shapes_lst, *links])
@@ -329,7 +329,7 @@ def create_detailed_form_diagram(root: Node, choices_config: dict, *, skip_notes
             continue
 
         link_label = get_form_link_label(node, choices_config)
-        link = draw_link(node.parent.question.name, node.question.name, link_label, dotted=is_low_confidence)
+        link = draw_link(node.parent.uid, node.uid, link_label, dotted=is_low_confidence)
         links.append(link)
 
     return "\n\t".join([header, *shapes_lst, *links])

--- a/pathways/typing/options.py
+++ b/pathways/typing/options.py
@@ -349,6 +349,15 @@ def exit_deadends(
                 node.add_child(new_node)
                 new_node.question.conditions = node.question.conditions.copy()
 
+                # Set choices_from_parent for mermaid diagram display
+                if node.question.choices:
+                    deadend_choice_objects = [
+                        choice for choice in node.question.choices
+                        if choice.name in deadend_choices
+                    ]
+                    if deadend_choice_objects:
+                        new_node.question.choices_from_parent = deadend_choice_objects
+
                 if len(deadend_choices) > 1:
                     conditions = [xpath_condition(var, "=", v) for v in deadend_choices]
                     expression = " or ".join(conditions)

--- a/pathways/typing/tree.py
+++ b/pathways/typing/tree.py
@@ -494,6 +494,8 @@ def filter_choices(choices: list[Choice], cart_rule: CARTRule) -> list[Choice]:
         raise TypingFormError(msg)
 
     for choice in choices:
+        if choice.cart_value in (None, ""):
+            continue
         if cart_rule.operator == ">" and float(choice.cart_value) >= cart_rule.value:
             filtered.append(choice)
         if cart_rule.operator == "<" and float(choice.cart_value) < cart_rule.value:


### PR DESCRIPTION
**Overview**

This PR improves how link labels are generated for calculate nodes in the Mermaid form diagram. Previously, calculate nodes link labels didn’t appear. The main change in this PR is that now it retrieves choice labels directly from the Excel configuration (choices_config) when they are not available in the tree, while preserving the original behavior for other cases.

**Summary of Changes**

**1. Retrieve labels from Excel configuration for calculate variables**
Calculate variables do not contain choices in the generated form tree (reason why is not clear). However, their corresponding labels may exist in the Excel configuration used to build the form. The logic now checks if the calculate node already has choices attached in the tree. If not, it attempts to retrieve the choices from choices_config, which is populated from the Excel file. The retrieved choices are converted into Choice objects and filtered using the existing `filter_choices` logic based on the CART rule. If matching labels are found, they are used for the diagram link.

[Examples from IDN TT](https://whimsical.com/idn-tt-choices-fix-BqEJki8phh64QcB6mvoiU7) (these labels were missing before)
<img width="781" height="491" alt="image" src="https://github.com/user-attachments/assets/55857202-0b9c-4d64-ab22-c7264ce7f99f" />
<img width="537" height="449" alt="image" src="https://github.com/user-attachments/assets/c84878d9-1a97-4167-abb8-865614094235" />

**2. Attach choices to dead-end nodes (exit_deadends) - (TODO: Test This)**
In `options.py`, the exit_deadends function was updated to set `New_node.question.choices_from_parent` when generating nodes for dead-end paths. Dead-end nodes are created when the CART tree reaches a branch without a valid next node. Since these nodes are not produced through the standard CART branching logic, they do not automatically carry the choice labels required for diagram edges. By `attaching choices_from_parent`, the diagram generation logic can correctly display the labels for these edges.

**3. Handle empty or missing `cart_value` in filter_choices** 
The `filter_choices` function was updated to skip choices with missing target values. This prevents runtime errors when the code attempts to convert an empty or missing value to a numeric type during CART rule comparisons (e.g. when evaluating conditions like > 1.5).
Without this safeguard, the filtering logic raises exceptions when encountering non-numeric values.

An example of this would be the `vehic_index_cat` variable in IDN TT in which is a 'calculate' node but doesn't have target values and the variable `vehic_index` is not present in the excel configuration so it would raise an exception.

<img width="909" height="82" alt="image" src="https://github.com/user-attachments/assets/f35f76c7-bf9e-48f2-8333-35a4cda3fc1c" />

**Current  Issue (Not resolved)** 

- There is a case in which if a calculate node is pointing to a question node then the label dissapears
<img width="413" height="295" alt="image" src="https://github.com/user-attachments/assets/659c9458-ac0f-4aca-8e95-ba5dff0f3255" />


**Notes**
There were changes to the `create_xlsform` pipeline too and its PR should be merged before this one to avoid errors. [PR Link](https://github.com/BLSQ/pathways-typing-pipelines/pull/5)